### PR TITLE
Implement `OSInterface_Timer`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(
         OSInterface
         GIT_REPOSITORY  git@github.com:vacmg/OSInterface.git
-        GIT_TAG         v0.3.0
+        GIT_TAG         v0.3.1
 )
 FetchContent_MakeAvailable(OSInterface)
 

--- a/Source/EspBinarySemaphore.cpp
+++ b/Source/EspBinarySemaphore.cpp
@@ -1,5 +1,5 @@
-#include "EspBinarySemaphore.h"
 #include "EspOSInterfaceLog.h"
+#include "EspBinarySemaphore.h"
 
 EspBinarySemaphore::EspBinarySemaphore(bool& result)
 {
@@ -20,7 +20,7 @@ void EspBinarySemaphore::signal()
     if (xSemaphoreGive(semaphore) == pdFALSE)
     {
         // Crash if we can't give the semaphore.
-        OSInterfaceLogError("EspOSInterface", "Failed to give semaphore");
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to give semaphore");
         abort();
     }
 }

--- a/Source/EspMutex.cpp
+++ b/Source/EspMutex.cpp
@@ -1,5 +1,5 @@
-#include "EspMutex.h"
 #include "EspOSInterfaceLog.h"
+#include "EspMutex.h"
 
 EspMutex::EspMutex(bool& result)
 {
@@ -20,7 +20,7 @@ void EspMutex::signal()
     if (xSemaphoreGive(mutex) == pdFALSE)
     {
         // Crash if we can't give the semaphore.
-        OSInterfaceLogError("EspOSInterface", "Failed to give mutex");
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to give mutex");
         abort();
     }
 }

--- a/Source/EspOSInterface.cpp
+++ b/Source/EspOSInterface.cpp
@@ -1,6 +1,7 @@
 #include "EspOSInterface.h"
 #include "EspBinarySemaphore.h"
 #include "EspMutex.h"
+#include "EspTimer.h"
 #include "EspUntypedQueue.h"
 
 #include <freertos/FreeRTOS.h>
@@ -43,7 +44,14 @@ OSInterface_BinarySemaphore* EspOSInterface::osCreateBinarySemaphore()
 OSInterface_Timer* EspOSInterface::osCreateTimer(uint32_t period, OSInterface_Timer::Mode mode,
                                                  OSInterfaceProcess callback, void* callbackArg, const char* timerName)
 {
-    return nullptr;
+    bool               result;
+    OSInterface_Timer* timer = new EspTimer(timerName, period, mode, callback, callbackArg, result);
+    if (!result)
+    {
+        delete timer;
+        return nullptr;
+    }
+    return timer;
 }
 
 OSInterface_UntypedQueue* EspOSInterface::osCreateUntypedQueue(uint32_t maxMessages, uint32_t messageSize)

--- a/Source/EspOSInterface.cpp
+++ b/Source/EspOSInterface.cpp
@@ -23,6 +23,7 @@ OSInterface_Mutex* EspOSInterface::osCreateMutex()
     OSInterface_Mutex* mutex = new EspMutex(result);
     if (!result)
     {
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to create mutex");
         delete mutex;
         return nullptr;
     }
@@ -35,31 +36,35 @@ OSInterface_BinarySemaphore* EspOSInterface::osCreateBinarySemaphore()
     OSInterface_BinarySemaphore* semaphore = new EspBinarySemaphore(result);
     if (!result)
     {
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to create binary semaphore");
         delete semaphore;
         return nullptr;
     }
     return semaphore;
 }
 
-OSInterface_Timer* EspOSInterface::osCreateTimer(uint32_t period, OSInterface_Timer::Mode mode,
-                                                 OSInterfaceProcess callback, void* callbackArg, const char* timerName)
+OSInterface_Timer* EspOSInterface::osCreateTimer(const uint32_t period, const OSInterface_Timer::Mode mode,
+                                                 const OSInterfaceProcess callback, void* callbackArg,
+                                                 const char* timerName)
 {
     bool               result;
     OSInterface_Timer* timer = new EspTimer(timerName, period, mode, callback, callbackArg, result);
     if (!result)
     {
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to create timer");
         delete timer;
         return nullptr;
     }
     return timer;
 }
 
-OSInterface_UntypedQueue* EspOSInterface::osCreateUntypedQueue(uint32_t maxMessages, uint32_t messageSize)
+OSInterface_UntypedQueue* EspOSInterface::osCreateUntypedQueue(const uint32_t maxMessages, const uint32_t messageSize)
 {
     bool             result;
     EspUntypedQueue* queue = new EspUntypedQueue(maxMessages, messageSize, result);
     if (!result)
     {
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to create untyped queue");
         delete queue;
         return nullptr;
     }
@@ -88,15 +93,15 @@ void EspOSInterface::osRunProcess(const OSInterfaceProcess process, const char* 
                                            processDefaultPriority, nullptr);
     if (res != pdPASS)
     {
-        OSInterfaceLogError("EspOSInterface", "Failed to create task for process %s", processName);
+        OSInterfaceLogError(EspOSInterfaceLogTag, "Failed to create task for process %s", processName);
         delete processData;
     }
 }
 
 void EspOSInterface::osRunProcessLauncher(void* data)
 {
-    auto* processData = static_cast<ProcessData*>(data);
-    OSInterfaceLogInfo("OSInterface", "Running process %s", processData->processName);
+    const ProcessData* processData = static_cast<ProcessData*>(data);
+    OSInterfaceLogInfo(EspOSInterfaceLogTag, "Running process %s", processData->processName);
     processData->process(processData->arg);
     delete processData;
     vTaskDelete(nullptr);

--- a/Source/EspTimer.cpp
+++ b/Source/EspTimer.cpp
@@ -1,0 +1,80 @@
+#include "EspTimer.h"
+
+EspTimer::EspTimer(const char* const pcTimerName, const TickType_t xTimerPeriod, const BaseType_t xAutoReload,
+                   void* const pvTimerID, TimerCallbackFunction_t pxCallbackFunction, bool& result)
+{
+    timer  = xTimerCreate(pcTimerName, xTimerPeriod, xAutoReload, pvTimerID, pxCallbackFunction);
+    result = (timer != nullptr);
+}
+
+EspTimer::~EspTimer()
+{
+    if (timer != nullptr)
+    {
+        xTimerDelete(timer, 0);
+    }
+}
+
+bool EspTimer::start()
+{
+    return xTimerStart(timer, 0) == pdPASS;
+}
+
+bool EspTimer::startFromISR()
+{
+    BaseType_t pxHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t res                       = xTimerStartFromISR(timer, &pxHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(pxHigherPriorityTaskWoken);
+    return res == pdPASS;
+}
+
+bool EspTimer::stop()
+{
+    return xTimerStop(timer, 0) == pdPASS;
+}
+
+bool EspTimer::stopFromISR()
+{
+    BaseType_t pxHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t res                       = xTimerStopFromISR(timer, &pxHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(pxHigherPriorityTaskWoken);
+    return res == pdPASS;
+}
+
+[[nodiscard]] bool EspTimer::isRunning() const
+{
+    return xTimerIsTimerActive(timer) != pdFALSE;
+}
+
+bool EspTimer::setPeriod(uint32_t newPeriod_ms)
+{
+    return xTimerChangePeriod(timer, pdMS_TO_TICKS(newPeriod_ms), 0) == pdPASS;
+}
+
+bool EspTimer::setPeriodFromISR(uint32_t newPeriod_ms)
+{
+    BaseType_t pxHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t res = xTimerChangePeriodFromISR(timer, pdMS_TO_TICKS(newPeriod_ms), &pxHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(pxHigherPriorityTaskWoken);
+    return res == pdPASS;
+}
+
+[[nodiscard]] uint32_t EspTimer::getPeriod() const
+{
+    return pdTICKS_TO_MS(xTimerGetPeriod(timer));
+}
+
+[[nodiscard]] EspTimer::Mode EspTimer::getMode() const
+{
+    return (xTimerGetReloadMode(timer) == pdTRUE) ? Mode::PERIODIC : Mode::ONE_SHOT;
+}
+
+[[nodiscard]] uint32_t EspTimer::getTimeout() const
+{
+    return pdTICKS_TO_MS(xTimerGetExpiryTime(timer) - xTaskGetTickCount());
+}
+
+[[nodiscard]] uint32_t EspTimer::getTimeoutTime() const
+{
+    return pdTICKS_TO_MS(xTimerGetExpiryTime(timer));
+}

--- a/Source/EspTimer.cpp
+++ b/Source/EspTimer.cpp
@@ -12,9 +12,11 @@ void EspTimer::callbackWrapper(TimerHandle_t xTimer)
 EspTimer::EspTimer(const char* const pcTimerName, const uint32_t timerPeriod, const OSInterface_Timer::Mode mode,
                    OSInterfaceProcess callback, void* callbackArgs, bool& result)
 {
-    timer  = xTimerCreate(pcTimerName, pdMS_TO_TICKS(timerPeriod),
-                         mode == OSInterface_Timer::PERIODIC ? pdTRUE : pdFALSE, this, callbackWrapper);
-    result = (timer != nullptr);
+    this->callbackFunction = callback;
+    this->callbackArgs     = callbackArgs;
+    this->timer            = xTimerCreate(pcTimerName, pdMS_TO_TICKS(timerPeriod),
+                               mode == OSInterface_Timer::PERIODIC ? pdTRUE : pdFALSE, this, callbackWrapper);
+    result                 = (this->timer != nullptr);
 }
 
 EspTimer::~EspTimer()

--- a/Source/EspTimer.cpp
+++ b/Source/EspTimer.cpp
@@ -9,13 +9,13 @@ void EspTimer::callbackWrapper(TimerHandle_t xTimer)
     }
 }
 
-EspTimer::EspTimer(const char* const pcTimerName, const uint32_t timerPeriod, const OSInterface_Timer::Mode mode,
+EspTimer::EspTimer(const char* const pcTimerName, const uint32_t timerPeriod, const Mode mode,
                    OSInterfaceProcess callback, void* callbackArgs, bool& result)
 {
     this->callbackFunction = callback;
     this->callbackArgs     = callbackArgs;
     this->timer            = xTimerCreate(pcTimerName, pdMS_TO_TICKS(timerPeriod),
-                               mode == OSInterface_Timer::PERIODIC ? pdTRUE : pdFALSE, this, callbackWrapper);
+                               mode == Mode::PERIODIC ? pdTRUE : pdFALSE, this, callbackWrapper);
     result                 = (this->timer != nullptr);
 }
 

--- a/Source/EspTimer.cpp
+++ b/Source/EspTimer.cpp
@@ -1,9 +1,19 @@
 #include "EspTimer.h"
 
-EspTimer::EspTimer(const char* const pcTimerName, const TickType_t xTimerPeriod, const BaseType_t xAutoReload,
-                   void* const pvTimerID, TimerCallbackFunction_t pxCallbackFunction, bool& result)
+void EspTimer::callbackWrapper(TimerHandle_t xTimer)
 {
-    timer  = xTimerCreate(pcTimerName, xTimerPeriod, xAutoReload, pvTimerID, pxCallbackFunction);
+    EspTimer* espTimer = static_cast<EspTimer*>(pvTimerGetTimerID(xTimer));
+    if (espTimer != nullptr && espTimer->callbackFunction != nullptr)
+    {
+        espTimer->callbackFunction(espTimer->callbackArgs);
+    }
+}
+
+EspTimer::EspTimer(const char* const pcTimerName, const uint32_t timerPeriod, const OSInterface_Timer::Mode mode,
+                   OSInterfaceProcess callback, void* callbackArgs, bool& result)
+{
+    timer  = xTimerCreate(pcTimerName, pdMS_TO_TICKS(timerPeriod),
+                         mode == OSInterface_Timer::PERIODIC ? pdTRUE : pdFALSE, this, callbackWrapper);
     result = (timer != nullptr);
 }
 

--- a/Source/EspUntypedQueue.cpp
+++ b/Source/EspUntypedQueue.cpp
@@ -1,3 +1,4 @@
+#include "EspOSInterfaceLog.h"
 #include "EspUntypedQueue.h"
 
 EspUntypedQueue::EspUntypedQueue(uint32_t maxMessages, uint32_t messageSize, bool& result)
@@ -19,30 +20,37 @@ uint32_t EspUntypedQueue::length()
 {
     return uxQueueMessagesWaiting(queue);
 }
+
 uint32_t EspUntypedQueue::size()
 {
     return maxMessages;
 }
+
 uint32_t EspUntypedQueue::available()
 {
     return uxQueueSpacesAvailable(queue);
 }
+
 bool EspUntypedQueue::isEmpty()
 {
     return uxQueueMessagesWaiting(queue) == 0;
 }
+
 bool EspUntypedQueue::isFull()
 {
     return uxQueueSpacesAvailable(queue) == 0;
 }
+
 void EspUntypedQueue::reset()
 {
     xQueueReset(queue);
 }
+
 bool EspUntypedQueue::receive(void* message, uint32_t maxTimeToWait_ms)
 {
     return xQueueReceive(queue, message, pdMS_TO_TICKS(maxTimeToWait_ms)) == pdTRUE;
 }
+
 bool EspUntypedQueue::receiveFromISR(void* message)
 {
     BaseType_t higherPriorityTaskWoken = pdFALSE;
@@ -50,10 +58,12 @@ bool EspUntypedQueue::receiveFromISR(void* message)
     portYIELD_FROM_ISR(higherPriorityTaskWoken);
     return res == pdTRUE;
 }
+
 bool EspUntypedQueue::sendToBack(const void* message, uint32_t maxTimeToWait_ms)
 {
     return xQueueSendToBack(queue, message, pdMS_TO_TICKS(maxTimeToWait_ms)) == pdTRUE;
 }
+
 bool EspUntypedQueue::sendToBackFromISR(const void* message)
 {
     BaseType_t higherPriorityTaskWoken = pdFALSE;
@@ -61,10 +71,12 @@ bool EspUntypedQueue::sendToBackFromISR(const void* message)
     portYIELD_FROM_ISR(higherPriorityTaskWoken);
     return res == pdTRUE;
 }
+
 bool EspUntypedQueue::sendToFront(const void* message, uint32_t maxTimeToWait_ms)
 {
     return xQueueSendToFront(queue, message, pdMS_TO_TICKS(maxTimeToWait_ms)) == pdTRUE;
 }
+
 bool EspUntypedQueue::sendToFrontFromISR(const void* message)
 {
     BaseType_t higherPriorityTaskWoken = pdFALSE;

--- a/Source/include/EspBinarySemaphore.h
+++ b/Source/include/EspBinarySemaphore.h
@@ -7,7 +7,7 @@
 class EspBinarySemaphore final : public OSInterface_BinarySemaphore
 {
 public:
-    EspBinarySemaphore(bool& result);
+    explicit EspBinarySemaphore(bool& result);
 
     ~EspBinarySemaphore() override;
 

--- a/Source/include/EspBinarySemaphore.h
+++ b/Source/include/EspBinarySemaphore.h
@@ -2,7 +2,7 @@
 #define ESPBINARYSEMAPHORE_H
 
 #include <freertos/FreeRTOS.h>
-#include "OSInterface.h"
+#include "OSInterface_BinarySemaphore.h"
 
 class EspBinarySemaphore final : public OSInterface_BinarySemaphore
 {

--- a/Source/include/EspMutex.h
+++ b/Source/include/EspMutex.h
@@ -2,7 +2,7 @@
 #define ESPMUTEX_H
 
 #include <freertos/FreeRTOS.h>
-#include "OSInterface.h"
+#include "OSInterface_Mutex.h"
 
 class EspMutex final : public OSInterface_Mutex
 {

--- a/Source/include/EspMutex.h
+++ b/Source/include/EspMutex.h
@@ -7,7 +7,7 @@
 class EspMutex final : public OSInterface_Mutex
 {
 public:
-    EspMutex(bool& result);
+    explicit EspMutex(bool& result);
 
     ~EspMutex() override;
 

--- a/Source/include/EspOSInterface.h
+++ b/Source/include/EspOSInterface.h
@@ -1,7 +1,6 @@
 #ifndef OSESPINTERFACE_H
 #define OSESPINTERFACE_H
 
-#include "EspOSInterfaceLog.h"
 #include "OSInterface.h"
 
 class EspOSInterface : public OSInterface
@@ -16,9 +15,9 @@ public:
     OSInterface_BinarySemaphore* osCreateBinarySemaphore() override;
 
     OSInterface_Timer* osCreateTimer(uint32_t period, OSInterface_Timer::Mode mode, OSInterfaceProcess callback,
-                                     void* callbackArg, const char* timerName);
+                                     void* callbackArg, const char* timerName) override;
 
-    OSInterface_UntypedQueue* osCreateUntypedQueue(uint32_t maxMessages, uint32_t messageSize);
+    OSInterface_UntypedQueue* osCreateUntypedQueue(uint32_t maxMessages, uint32_t messageSize) override;
 
     void* osMalloc(uint32_t size) override;
 

--- a/Source/include/EspOSInterface.h
+++ b/Source/include/EspOSInterface.h
@@ -1,6 +1,7 @@
 #ifndef OSESPINTERFACE_H
 #define OSESPINTERFACE_H
 
+#include "EspOSInterfaceLog.h" // Must be included before OSInterface.h to override logging macros
 #include "OSInterface.h"
 
 class EspOSInterface : public OSInterface

--- a/Source/include/EspOSInterfaceLog.h
+++ b/Source/include/EspOSInterfaceLog.h
@@ -2,41 +2,37 @@
 #define ESPOSINTERFACELOG_H
 
 #include "esp_log.h"
-#include "OSInterface.h"
 
-#ifdef OSInterfaceLogVerbose
-    #undef OSInterfaceLogVerbose
-#endif
-#define OSInterfaceLogVerbose(tag, format, ...) ESP_LOGV(tag, format, ##__VA_ARGS__)
+constexpr const char* EspOSInterfaceLogTag = "EspOSInterface";
 
-#ifdef OSInterfaceLogDebug
-    #undef OSInterfaceLogDebug
+#ifndef OSInterfaceLogVerbose
+    #define OSInterfaceLogVerbose(tag, format, ...) ESP_LOGV(tag, format, ##__VA_ARGS__)
 #endif
-#define OSInterfaceLogDebug(tag, format, ...) ESP_LOGD(tag, format, ##__VA_ARGS__)
 
-#ifdef OSInterfaceLogInfo
-    #undef OSInterfaceLogInfo
+#ifndef OSInterfaceLogDebug
+    #define OSInterfaceLogDebug(tag, format, ...) ESP_LOGD(tag, format, ##__VA_ARGS__)
 #endif
-#define OSInterfaceLogInfo(tag, format, ...) ESP_LOGI(tag, format, ##__VA_ARGS__)
 
-#ifdef OSInterfaceLogWarning
-    #undef OSInterfaceLogWarning
+#ifndef OSInterfaceLogInfo
+    #define OSInterfaceLogInfo(tag, format, ...) ESP_LOGI(tag, format, ##__VA_ARGS__)
 #endif
-#define OSInterfaceLogWarning(tag, format, ...) ESP_LOGW(tag, AT format, ##__VA_ARGS__)
 
-#ifdef OSInterfaceLogError
-    #undef OSInterfaceLogError
+#ifndef OSInterfaceLogWarning
+    #define OSInterfaceLogWarning(tag, format, ...) ESP_LOGW(tag, AT format, ##__VA_ARGS__)
 #endif
-#define OSInterfaceLogError(tag, format, ...) ESP_LOGE(tag, AT format, ##__VA_ARGS__)
 
-#ifdef OSInterfaceSetLogLevel
-    #undef OSInterfaceSetLogLevel
+#ifndef OSInterfaceLogError
+    #define OSInterfaceLogError(tag, format, ...) ESP_LOGE(tag, AT format, ##__VA_ARGS__)
 #endif
-#define OSInterfaceSetLogLevel(tag, level) esp_log_level_set(tag, static_cast<esp_log_level_t>(level))
 
-#ifdef OSInterfaceGetLogLevel
-    #undef OSInterfaceGetLogLevel
+#ifndef OSInterfaceSetLogLevel
+    #define OSInterfaceSetLogLevel(tag, level) esp_log_level_set(tag, static_cast<esp_log_level_t>(level))
 #endif
-#define OSInterfaceGetLogLevel(tag) esp_log_get_level(tag)
+
+#ifndef OSInterfaceGetLogLevel
+    #define OSInterfaceGetLogLevel(tag) esp_log_get_level(tag)
+#endif
+
+#include "OSInterface_Log.h"
 
 #endif // ESPOSINTERFACELOG_H

--- a/Source/include/EspOSInterfaceLog.h
+++ b/Source/include/EspOSInterfaceLog.h
@@ -2,6 +2,7 @@
 #define ESPOSINTERFACELOG_H
 
 #include "esp_log.h"
+#include "OSInterface.h"
 
 #ifdef OSInterfaceLogVerbose
     #undef OSInterfaceLogVerbose

--- a/Source/include/EspTimer.h
+++ b/Source/include/EspTimer.h
@@ -8,8 +8,8 @@
 class EspTimer final : public OSInterface_Timer
 {
 public:
-    EspTimer(const char* pcTimerName, uint32_t timerPeriod, Mode mode,
-             OSInterfaceProcess callback, void* callbackArgs, bool& result);
+    EspTimer(const char* pcTimerName, uint32_t timerPeriod, Mode mode, OSInterfaceProcess callback, void* callbackArgs,
+             bool& result);
 
     ~EspTimer() override;
 

--- a/Source/include/EspTimer.h
+++ b/Source/include/EspTimer.h
@@ -2,13 +2,14 @@
 #define ESPTIMER_H
 
 #include <freertos/FreeRTOS.h>
+#include "OSInterface.h"
 #include "OSInterface_Timer.h"
 
 class EspTimer final : public OSInterface_Timer
 {
 public:
-    EspTimer(const char* pcTimerName, TickType_t xTimerPeriod, BaseType_t xAutoReload, void* pvTimerID,
-             TimerCallbackFunction_t pxCallbackFunction, bool& result);
+    EspTimer(const char* pcTimerName, uint32_t TimerPeriod, OSInterface_Timer::Mode mode,
+             OSInterfaceProcess callback, void* callbackArgs, bool& result);
 
     ~EspTimer() override;
 
@@ -36,6 +37,11 @@ public:
 
 private:
     TimerHandle_t timer{};
+
+    OSInterfaceProcess callbackFunction{};
+    void*              callbackArgs{};
+
+    static void callbackWrapper(TimerHandle_t xTimer);
 };
 
 #endif // ESPTIMER_H

--- a/Source/include/EspTimer.h
+++ b/Source/include/EspTimer.h
@@ -1,0 +1,41 @@
+#ifndef ESPTIMER_H
+#define ESPTIMER_H
+
+#include <freertos/FreeRTOS.h>
+#include "OSInterface_Timer.h"
+
+class EspTimer final : public OSInterface_Timer
+{
+public:
+    EspTimer(const char* pcTimerName, TickType_t xTimerPeriod, BaseType_t xAutoReload, void* pvTimerID,
+             TimerCallbackFunction_t pxCallbackFunction, bool& result);
+
+    ~EspTimer() override;
+
+    bool start() override;
+
+    bool startFromISR() override;
+
+    bool stop() override;
+
+    bool stopFromISR() override;
+
+    [[nodiscard]] bool isRunning() const override;
+
+    bool setPeriod(uint32_t newPeriod_ms) override;
+
+    bool setPeriodFromISR(uint32_t newPeriod_ms) override;
+
+    [[nodiscard]] uint32_t getPeriod() const override;
+
+    [[nodiscard]] Mode getMode() const override;
+
+    [[nodiscard]] uint32_t getTimeout() const override;
+
+    [[nodiscard]] uint32_t getTimeoutTime() const override;
+
+private:
+    TimerHandle_t timer{};
+};
+
+#endif // ESPTIMER_H

--- a/Source/include/EspTimer.h
+++ b/Source/include/EspTimer.h
@@ -8,7 +8,7 @@
 class EspTimer final : public OSInterface_Timer
 {
 public:
-    EspTimer(const char* pcTimerName, uint32_t TimerPeriod, OSInterface_Timer::Mode mode,
+    EspTimer(const char* pcTimerName, uint32_t timerPeriod, Mode mode,
              OSInterfaceProcess callback, void* callbackArgs, bool& result);
 
     ~EspTimer() override;

--- a/Source/include/EspUntypedQueue.h
+++ b/Source/include/EspUntypedQueue.h
@@ -7,7 +7,7 @@
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
-#include "OSInterface.h"
+#include "OSInterface_UntypedQueue.h"
 
 class EspUntypedQueue final : public OSInterface_UntypedQueue
 {

--- a/Source/include/EspUntypedQueue.h
+++ b/Source/include/EspUntypedQueue.h
@@ -13,7 +13,7 @@ class EspUntypedQueue final : public OSInterface_UntypedQueue
 {
 public:
     EspUntypedQueue(uint32_t maxMessages, uint32_t messageSize, bool& result);
-    ~EspUntypedQueue();
+    ~EspUntypedQueue() override;
 
     uint32_t length() override;
     uint32_t size() override;

--- a/test-project/dependencies.lock
+++ b/test-project/dependencies.lock
@@ -2,7 +2,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.0
+    version: 5.5.2
 direct_dependencies:
 - idf
 manifest_hash: 1e62c371b6804b00b04cf840d699047443a184d8aa03b2c4fdbad21739dd2775

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,8 +1,8 @@
 #include <EspOSInterface.h>
 #include <EspUntypedQueue.h>
 #include <unity.h>
-#include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_log.h"
 
 EspOSInterface espOSInterface;
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -31,21 +31,21 @@ TEST_CASE("timeTest", "[EspOSInterface]")
     }
 }
 
-TEST_CASE("osMallocSimpleAlloc", "[espOSInterface]")
+TEST_CASE("osMallocSimpleAlloc", "[EspOSInterface]")
 {
     void* ptr = espOSInterface.osMalloc(100);
     TEST_ASSERT_NOT_NULL(ptr);
     espOSInterface.osFree(ptr);
 }
 
-TEST_CASE("osMallocZeroAlloc", "[espOSInterface]")
+TEST_CASE("osMallocZeroAlloc", "[EspOSInterface]")
 {
     void* ptr = espOSInterface.osMalloc(0);
     TEST_ASSERT_NULL(ptr);
     espOSInterface.osFree(ptr);
 }
 
-TEST_CASE("osMallocLargeAlloc", "[espOSInterface]")
+TEST_CASE("osMallocLargeAlloc", "[EspOSInterface]")
 {
     void* ptr = espOSInterface.osMalloc(1024 * 100);
     ESP_LOGE("TEST", "XXX large ptr: %p", ptr);
@@ -53,7 +53,7 @@ TEST_CASE("osMallocLargeAlloc", "[espOSInterface]")
     espOSInterface.osFree(ptr);
 }
 
-TEST_CASE("osMallocMultipleAlloc", "[espOSInterface]")
+TEST_CASE("osMallocMultipleAlloc", "[EspOSInterface]")
 {
     void* ptr1 = espOSInterface.osMalloc(100);
     void* ptr2 = espOSInterface.osMalloc(100);
@@ -68,7 +68,7 @@ TEST_CASE("osMallocMultipleAlloc", "[espOSInterface]")
 
 // **** Mutex Tests ****
 
-TEST_CASE("mutexWait", "[espOSInterface]")
+TEST_CASE("mutexWait", "[EspMutex]")
 {
     OSInterface_Mutex* mutex = espOSInterface.osCreateMutex();
     TEST_ASSERT_NOT_NULL(mutex);
@@ -90,7 +90,7 @@ static void secondMutexTask(void* arg)
     vTaskDelete(nullptr);
 }
 
-TEST_CASE("mutexTestNormal", "[espOSInterface]")
+TEST_CASE("mutexTestNormal", "[EspMutex]")
 {
     s_mutex = espOSInterface.osCreateMutex();
     TEST_ASSERT_NOT_NULL(s_mutex);
@@ -123,7 +123,7 @@ static void secondMutexTimeoutTask(void* arg)
     vTaskDelete(nullptr);
 }
 
-TEST_CASE("mutexTestTimeout", "[espOSInterface]")
+TEST_CASE("mutexTestTimeout", "[EspMutex]")
 {
     s_mutex = espOSInterface.osCreateMutex();
     TEST_ASSERT_NOT_NULL(s_mutex);
@@ -144,7 +144,7 @@ TEST_CASE("mutexTestTimeout", "[espOSInterface]")
 
 // **** Binary Semaphore Tests ****
 
-TEST_CASE("binarySemaphoreInit", "[espOSInterface]")
+TEST_CASE("binarySemaphoreInit", "[EspBinarySemaphore]")
 {
     OSInterface_BinarySemaphore* semaphore = espOSInterface.osCreateBinarySemaphore();
     TEST_ASSERT_NOT_NULL(semaphore);
@@ -152,7 +152,7 @@ TEST_CASE("binarySemaphoreInit", "[espOSInterface]")
     delete semaphore;
 }
 
-TEST_CASE("binarySemaphoreWaitSignal", "[espOSInterface]")
+TEST_CASE("binarySemaphoreWaitSignal", "[EspBinarySemaphore]")
 {
     OSInterface_BinarySemaphore* semaphore = espOSInterface.osCreateBinarySemaphore();
     TEST_ASSERT_NOT_NULL(semaphore);
@@ -161,7 +161,7 @@ TEST_CASE("binarySemaphoreWaitSignal", "[espOSInterface]")
     delete semaphore;
 }
 
-TEST_CASE("binarySemaphoreWaitSignalWait", "[espOSInterface]")
+TEST_CASE("binarySemaphoreWaitSignalWait", "[EspBinarySemaphore]")
 {
     OSInterface_BinarySemaphore* semaphore = espOSInterface.osCreateBinarySemaphore();
     TEST_ASSERT_NOT_NULL(semaphore);
@@ -185,7 +185,7 @@ static void secondSemTask(void* arg)
     vTaskDelete(nullptr);
 }
 
-TEST_CASE("semaphoreTestNormal", "[espOSInterface]")
+TEST_CASE("semaphoreTestNormal", "[EspBinarySemaphore]")
 {
     s_semaphore = espOSInterface.osCreateBinarySemaphore();
     TEST_ASSERT_NOT_NULL(s_semaphore);
@@ -219,7 +219,7 @@ static void secondSemTimeoutTask(void* arg)
     vTaskDelete(nullptr);
 }
 
-TEST_CASE("semaphoreTestTimeout", "[espOSInterface]")
+TEST_CASE("semaphoreTestTimeout", "[EspBinarySemaphore]")
 {
     s_semaphore = espOSInterface.osCreateBinarySemaphore();
     TEST_ASSERT_NOT_NULL(s_semaphore);
@@ -246,7 +246,7 @@ void runProcessTest(void* arg)
     *processRun = true;
 }
 
-TEST_CASE("runProcessTest", "[espOSInterface]")
+TEST_CASE("runProcessTest", "[EspOSInterface]")
 {
     volatile bool processRun = false;
     void*         arg        = (void*)(&processRun);
@@ -263,7 +263,7 @@ TEST_CASE("runProcessTest", "[espOSInterface]")
 
 // **** Untyped Queue Tests ****
 
-TEST_CASE("untypedQueueSendReceive", "[espOSInterface]")
+TEST_CASE("untypedQueueSendReceive", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(1, sizeof(uint32_t), created);
@@ -277,7 +277,7 @@ TEST_CASE("untypedQueueSendReceive", "[espOSInterface]")
     TEST_ASSERT_EQUAL(0, queue.length());
 }
 
-TEST_CASE("untypedQueueSendFull", "[espOSInterface]")
+TEST_CASE("untypedQueueSendFull", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(1, sizeof(uint32_t), created);
@@ -287,7 +287,7 @@ TEST_CASE("untypedQueueSendFull", "[espOSInterface]")
     TEST_ASSERT_FALSE(queue.sendToBack(&item, 10)); // Queue is full
 }
 
-TEST_CASE("untypedQueueReceiveEmpty", "[espOSInterface]")
+TEST_CASE("untypedQueueReceiveEmpty", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(1, sizeof(uint32_t), created);
@@ -296,7 +296,7 @@ TEST_CASE("untypedQueueReceiveEmpty", "[espOSInterface]")
     TEST_ASSERT_FALSE(queue.receive(&item, 10)); // Queue is empty
 }
 
-TEST_CASE("untypedQueueCount", "[espOSInterface]")
+TEST_CASE("untypedQueueCount", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(5, sizeof(uint32_t), created);
@@ -315,7 +315,7 @@ TEST_CASE("untypedQueueCount", "[espOSInterface]")
     TEST_ASSERT_EQUAL(0, queue.length());
 }
 
-TEST_CASE("untypedQueueIsEmpty", "[espOSInterface]")
+TEST_CASE("untypedQueueIsEmpty", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(2, sizeof(uint32_t), created);
@@ -323,7 +323,7 @@ TEST_CASE("untypedQueueIsEmpty", "[espOSInterface]")
     TEST_ASSERT_TRUE(queue.isEmpty());
 }
 
-TEST_CASE("untypedQueueIsFull", "[espOSInterface]")
+TEST_CASE("untypedQueueIsFull", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(1, sizeof(uint32_t), created);
@@ -333,7 +333,7 @@ TEST_CASE("untypedQueueIsFull", "[espOSInterface]")
     TEST_ASSERT_TRUE(queue.isFull());
 }
 
-TEST_CASE("untypedQueueAvailable", "[espOSInterface]")
+TEST_CASE("untypedQueueAvailable", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(3, sizeof(uint32_t), created);
@@ -344,7 +344,7 @@ TEST_CASE("untypedQueueAvailable", "[espOSInterface]")
     TEST_ASSERT_EQUAL(2, queue.available());
 }
 
-TEST_CASE("untypedQueueReset", "[espOSInterface]")
+TEST_CASE("untypedQueueReset", "[EspUntypedQueue]")
 {
     bool            created;
     EspUntypedQueue queue(2, sizeof(uint32_t), created);


### PR DESCRIPTION
Implements new class `EspTimer` from interface `OSInterface_Timer`

> [!NOTE]
> To correctly wrap `OSInterface` function pointer and args to the expected `TimeCallbackFunction_T` on FreeRTOS, the pointers are stored as members of the `EspTimer` instance and a pointer to this instance is set as the `TimerHandle_t` ID in order for the static wrapper method to access it.